### PR TITLE
added new header button for logged in user

### DIFF
--- a/groupyz/src/Header.jsx
+++ b/groupyz/src/Header.jsx
@@ -1,8 +1,14 @@
 import "./styles/Header.css";
 import Logo from "./assets/images/logo.svg";
 import Button_c from "./components/global/Button_c";
+import LoginSignupButtons from "./components/global/LoginSignupButtons";
+import { useLocation } from "react-router-dom";
+import ScheduleButton from "./components/global/ScheduleButton";
 
 const Header = () => {
+  const location = useLocation();
+  const isLoggedIn =
+    location.pathname === "/addgroups" || location.pathname === "/qr";
   return (
     <header>
       <div class="container">
@@ -10,12 +16,7 @@ const Header = () => {
           <img src={Logo} width={112} height={112} alt="logo" />
         </div>
         <div class="scheduleContainer">{`Schedule messages`}</div>
-        <div class="loginButton">
-          <Button_c name="Log in" dest="./login" />
-        </div>
-        <div class="signupButton">
-          <Button_c name="Sign up" dest="./signup" />
-        </div>
+        {isLoggedIn ? <ScheduleButton /> : <LoginSignupButtons />}
       </div>
     </header>
   );

--- a/groupyz/src/assets/images/plus.svg
+++ b/groupyz/src/assets/images/plus.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="29" height="24" viewBox="0 0 29 24" fill="none">
+  <path d="M22.3439 12.998H15.2879V18.998H12.9359V12.998H5.87988V10.998H12.9359V4.99799H15.2879V10.998H22.3439V12.998Z" fill="#22577A"/>
+</svg>

--- a/groupyz/src/components/global/LoginSignupButtons.jsx
+++ b/groupyz/src/components/global/LoginSignupButtons.jsx
@@ -1,0 +1,17 @@
+import "../../styles/Header.css";
+import Button_c from "./Button_c";
+
+const LoginSignupButtons = () => {
+  return (
+    <div class="loginSignupContainer">
+      <div class="loginButton">
+        <Button_c name="Log in" dest="./login" />
+      </div>
+      <div class="signupButton">
+        <Button_c name="Sign up" dest="./signup" />
+      </div>
+    </div>
+  );
+};
+
+export default LoginSignupButtons;

--- a/groupyz/src/components/global/ScheduleButton.jsx
+++ b/groupyz/src/components/global/ScheduleButton.jsx
@@ -1,0 +1,13 @@
+import "./styles/ScheduleButton.css";
+import Button_c from "./Button_c";
+import plus from "../../assets/images/plus.svg";
+
+const ScheduleButton = () => {
+  return (
+    <div class="schedule">
+      <Button_c image={plus} name="Schedule a new message" />
+    </div>
+  );
+};
+
+export default ScheduleButton;

--- a/groupyz/src/components/global/styles/Button_c.css
+++ b/groupyz/src/components/global/styles/Button_c.css
@@ -7,4 +7,5 @@
 .image {
   justify-content: left;
   padding: 0.5rem;
+  padding-top: 1rem
 }

--- a/groupyz/src/components/global/styles/ScheduleButton.css
+++ b/groupyz/src/components/global/styles/ScheduleButton.css
@@ -1,0 +1,19 @@
+.schedule {
+    padding-top: 3rem;
+    padding-right: 3rem;
+}
+
+.schedule #Button_c {
+    width: 290px;
+    height: 54px;
+    border-radius: 20px;
+    border: 2px solid #22577A;
+    color: #22577A;
+    font-weight: 600;
+    background: none;
+    padding: 1rem;
+}
+
+.schedule .img  {
+    padding-top: 0.5rem;
+}

--- a/groupyz/src/styles/Header.css
+++ b/groupyz/src/styles/Header.css
@@ -6,6 +6,11 @@ header .container {
     grid-gap: 1.5rem;
 }
 
+.loginSignupContainer {
+    display: grid;
+    grid-template-columns: auto auto;
+}
+
 header .container .logoContainer {
     grid-column: 1;
     display: flex;
@@ -22,7 +27,7 @@ header .container .logoContainer {
     color: #38A3A5;
 }
 header .loginButton {
-    grid-column: 3;
+    grid-column: 1;
     grid-row: 1;
     display: flex;
     justify-content: flex-start;
@@ -41,7 +46,7 @@ header .loginButton #Button_c {
 }
 
 header .signupButton {
-    grid-column: 3;
+    grid-column: 2;
     grid-row:1;
     display: flex;
     justify-content: flex-end;


### PR DESCRIPTION
Problem: After login the header still had 'login' and 'signup' buttons instead of 'schedule a new message' button
Solution: added the button to the relevant pages
Impact: when logged in to your user, the relevant button will appear in the header
Testing plan: make sure the button appears in the relevant pages only (qr, addgroups --> new button, everything else --> old buttons)