### PR TITLE
added new header button for logged in user

### DIFF
--- a/groupyz/src/Header.jsx
+++ b/groupyz/src/Header.jsx
@@ -8,7 +8,9 @@ import ScheduleButton from "./components/global/ScheduleButton";
 const Header = () => {
   const location = useLocation();
   const isLoggedIn =
-    location.pathname === "/addgroups" || location.pathname === "/qr";
+    location.pathname.toLowerCase() !== "/" &&
+    location.pathname.toLowerCase() !== "/login" &&
+    location.pathname.toLowerCase() !== "/signup";
   return (
     <header>
       <div class="container">


### PR DESCRIPTION
Problem: After login the header still had 'login' and 'signup' buttons instead of 'schedule a new message' button
Solution: added the button to the relevant pages
Impact: when logged in to your user, the relevant button will appear in the header
Testing plan: make sure the button appears in the relevant pages only (qr, addgroups --> new button, everything else --> old buttons)