### PR TITLE
schedule button now functional

### DIFF
--- a/groupyz/src/components/global/ScheduleButton.jsx
+++ b/groupyz/src/components/global/ScheduleButton.jsx
@@ -5,7 +5,7 @@ import plus from "../../assets/images/plus.svg";
 const ScheduleButton = () => {
   return (
     <div class="schedule">
-      <Button_c image={plus} name="Schedule a new message" />
+      <Button_c image={plus} name="Schedule a new message" dest="./addgroups" />
     </div>
   );
 };

--- a/groupyz/src/pages/dashboard/dashboard.jsx
+++ b/groupyz/src/pages/dashboard/dashboard.jsx
@@ -26,7 +26,7 @@ const Dashboard = () => (
             </p>
           </div>
           <div className="createButton">
-            <Button_c name=" +  Schedule a new message" />
+            <Button_c name=" +  Schedule a new message" dest="./addgroups" />
           </div>
           <div className="img">
             <img src={dashboard} alt="" />


### PR DESCRIPTION
Problem: 'schedule new message' button on site after login wasnt functional.
Solution: button now functional and rerouting to add groups page.
Test: make sure the button on all the logged in pages works + the other schedule button on the dashboard page.