### PR TITLE
Send message json fix

### DIFF
--- a/groupyz/src/pages/new_message/newMessage.jsx
+++ b/groupyz/src/pages/new_message/newMessage.jsx
@@ -57,7 +57,7 @@ const NewMessage = () => {
     const data = JSON.stringify({
       user_id: 1,
       repeat: "once",
-      dest_groups_id: destGroupsId,
+      group_ids: destGroupsId,
       time_to_send: timeToSend,
       message_data: messageData,
       message_title: messageTitle,


### PR DESCRIPTION
Problem: send message POST body was not compatible with expected input to messages server
Solution: changed 'dest_groups_id' field to the correct one 'group_ids'
Test: run the app, run the messages server (could also copy code to big repo and run it), go to send message page, create a message and save it, check if message was saved to db. 